### PR TITLE
Updated to use signals and added "advance" command.

### DIFF
--- a/opt/PiPass/piPass.py
+++ b/opt/PiPass/piPass.py
@@ -110,7 +110,19 @@ def sigUsr1(signum, stack):
     loadSettings()
     print("\n< Update Detected! - Using new updated Nintendo Zones. >\n")
 
+def sigUsr2(signum, stack):
+    '''
+    Handles SIGUSR1, which is interpreted as a request to advance the zone.
+    '''
+    global start
+    # The time elapsed loop records its start time in "start". By setting to 0,
+    # this forces the elapsed time to a huge number which results in advancing
+    # to the next zone.
+    start = 0
+    print("\n< Advance Detected! - Advancing to next Zone. >\n")
+
 signal.signal(signal.SIGUSR1, sigUsr1)
+signal.signal(signal.SIGUSR2, sigUsr2)
 
 print("> PiPass is currently running...")
 

--- a/opt/PiPass/piPass.py
+++ b/opt/PiPass/piPass.py
@@ -8,6 +8,7 @@ import urllib
 import json
 import time
 import io
+import signal
 
 #### Support Functions ####
 
@@ -93,9 +94,6 @@ CURRENT_LIST = "/var/www/assets/json/current_list.json"
 # Flag that informs PiPass that updates have been made to PIPASS_DB and to use those updates. Default value is "execute".
 piPassStatus = "execute"
 
-# Temporary flag file path for piPassStatus.
-FLAG_PATH = "/tmp/pipass_flag.txt"
-
 # Converting STREETPASS_CYCLE_MINUTES to seconds.
 STREETPASS_CYCLE_SECONDS = STREETPASS_CYCLE_MINUTES * 60
 
@@ -103,10 +101,16 @@ STREETPASS_CYCLE_SECONDS = STREETPASS_CYCLE_MINUTES * 60
 
 print("[ PiPass - Homepass for the Nintendo 3DS ]\n")
 
-# Create/Overwrite flag file for piPassStatus.
-fo = open(FLAG_PATH, "w")
-fo.write(piPassStatus)
-fo.close()
+def sigUsr1(signum, stack):
+    '''
+    Handles SIGUSR1, which is interpreted as a request to update settings.
+    '''
+    global piPassStatus
+    piPassStatus = "update"
+    loadSettings()
+    print("\n< Update Detected! - Using new updated Nintendo Zones. >\n")
+
+signal.signal(signal.SIGUSR1, sigUsr1)
 
 print("> PiPass is currently running...")
 
@@ -130,26 +134,9 @@ while "Waiting for Half-Life 3":
 
     # Begin looping through all the Nintendo Zones in the collection.
     for data in results['feed']['entry']:
-        # Open the flag file and read in the value.
-        fo = open(FLAG_PATH)
-        piPassStatus = fo.read()
-        fo.close()
-
-        # If the user has issued an update, then reload PIPASS_DB for the updated Nintendo Zones.
-        if piPassStatus == "update\n":
-            # We want PiPass to keep running.
+        # If the user has issued an update, then restart with the updated Nintendo Zones.
+        if piPassStatus == "update":
             piPassStatus = "execute"
-
-            # Overwrite flag file for piPassStatus.
-            fo = open(FLAG_PATH, "w")
-            fo.write(piPassStatus)
-            fo.close()
-
-            # Refresh settings.
-            loadSettings()
-
-            print("\n< Update Detected! - Using new updated Nintendo Zones. >\n")
-
             break
 
         # Write the current zone information to NETWORK_CONFIGURATION.
@@ -184,4 +171,9 @@ while "Waiting for Half-Life 3":
         # Restart hostapd to ensure NETWORK_CONFIGURATION is used and pause for STREETPASS_CYCLE_MINUTES until moving onto the next Nintendo Zone.
         # Restarting hostapd will also ensure that it is running if it is currently off.
         subprocess.Popen('sudo service hostapd restart', shell=True, stdout=subprocess.PIPE)
-        time.sleep(STREETPASS_CYCLE_SECONDS)
+
+	# Receiving SIGUSR1 will interrupt the time.sleep call. The loop allows
+	# for sleep to be resumed up to the current cycle setting.
+        start = time.time()
+        while time.time() - start < STREETPASS_CYCLE_SECONDS:
+            time.sleep(5)

--- a/opt/PiPass/piPassCommand.py
+++ b/opt/PiPass/piPassCommand.py
@@ -24,6 +24,7 @@ def updateStatus():
 # Print out command interface.
 def printCommandInterface():
     print("\nupdate : PiPass will use updated Nintendo Zone list.")
+    print("advance : Advances PiPass to next entry in list.")
     print("stop : Stops PiPass.")
     print("start : Starts PiPass.")
     print("piRestart : Restarts the Raspberry Pi.")
@@ -47,6 +48,9 @@ if command == "update":
     # Web GUI: PiPass -> Refresh
     subprocess.Popen('sudo pkill --signal SIGUSR1 -f piPass.py', shell=True, stdout=subprocess.PIPE)
     print("Using updated Nintendo Zone list.\n")
+elif command == "advance":
+    subprocess.Popen('sudo pkill --signal SIGUSR2 -f piPass.py', shell=True, stdout=subprocess.PIPE)
+    print("PiPass advanced to next entry.\n")
 elif command == "stop":
     # Web GUI: PiPass -> Stop
     updateStatus()

--- a/opt/PiPass/piPassCommand.py
+++ b/opt/PiPass/piPassCommand.py
@@ -45,7 +45,7 @@ command = sys.argv[1]
 # Command switchboard for PiPass commands.
 if command == "update":
     # Web GUI: PiPass -> Refresh
-    subprocess.Popen('sudo echo "update" > /tmp/pipass_flag.txt', shell=True, stdout=subprocess.PIPE)
+    subprocess.Popen('sudo pkill --signal SIGUSR1 -f piPass.py', shell=True, stdout=subprocess.PIPE)
     print("Using updated Nintendo Zone list.\n")
 elif command == "stop":
     # Web GUI: PiPass -> Stop

--- a/var/www/advance_pi_pass.html
+++ b/var/www/advance_pi_pass.html
@@ -2,9 +2,6 @@
 <html lang="en">
   <head>
     <meta charset="utf-8">
-    <meta http-equiv="Cache-Control" content="no-cache, no-store, must-revalidate">
-    <meta http-equiv="Pragma" content="no-cache">
-    <meta http-equiv="Expires" content="0">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <meta name="description" content="PiPass Dashboard for the Raspberry Pi">
     <meta name="author" content="Matthew Hsu">
@@ -23,9 +20,18 @@
     <link href="assets/css/style.css" rel="stylesheet">
     <link href="assets/css/style-responsive.css" rel="stylesheet">
 
-    <!-- JQUERY -->
-    <script src="https://ajax.googleapis.com/ajax/libs/jquery/2.1.3/jquery.min.js"></script>
-    <script src="assets/js/jquery.loadJSON.js"></script>
+    <!-- CALLS REFRESH.PHP TO EXECUTE SERVER SIDE COMMANDS -->
+    <script>
+      function advance()
+      {
+        var xmlHttp = new XMLHttpRequest();
+
+        xmlHttp.open("POST","assets/php/advance.php",true);
+        xmlHttp.send();
+
+        alert("Advance complete! - The next Zone should be available momentarily.");
+      }
+    </script>
   </head>
 
   <body>
@@ -67,8 +73,8 @@
                           <li><a  href="start_pi_pass.html">Start</a></li>
                           <li><a  href="stop_pi_pass.html">Stop</a></li>
                           <li><a  href="refresh_pi_pass.html">Refresh</a></li>
-                          <li><a  href="advance_pi_pass.html">Advance</a></li>
-                          <li class="active"><a  href="settings.html">Settings</a></li>
+                          <li class="active"><a  href="advance_pi_pass.html">Advance</a></li>
+                          <li><a  href="settings.html">Settings</a></li>
                       </ul>
                   </li>
 
@@ -102,50 +108,16 @@
       <!-- MAIN CONTENT START -->
       <section id="main-content">
         <section class="wrapper site-min-height">
-          <h3><i class="fa fa-angle-right"></i> Settings</h3>
-          <!-- BASIC FORM ELELEMNTS -->
+          <h3><i class="fa fa-angle-right"></i> Advance</h3>
           <div class="row mt">
             <div class="col-lg-12">
-              <div class="form-panel">
-                <h4 class="mb"><i class="fa fa-angle-right"></i> Configure PiPass</h4>
-                <form class="form-horizontal style-form" onsubmit="return alert('Settings Saved! - Please refresh or restart PiPass for the settings to take effect.');" action="assets/php/settings.php" method="post">
-                  <div class="form-group">
-                    <label class="col-sm-2 col-sm-2 control-label">StreetPass Cycle Time (Minutes)</label>
-                    <div class="col-sm-1">
-                        <input type="text" class="form-control round-form" id="STREETPASS_CYCLE_MINUTES" name="STREETPASS_CYCLE_MINUTES" required>
-                    </div>
-                  </div>
-                  <div class="form-group">
-                    <label class="col-sm-2 col-sm-2 control-label">Shuffle Zones</label>
-                    <div class="col-sm-1">
-                        <input type="checkbox" id="PIPASS_SHUFFLE" name="PIPASS_SHUFFLE">
-                    </div>
-                  </div>
-                  <div class="form-group">
-                    <label class="col-sm-2 col-sm-2 control-label">PiPass DB Key</label>
-                    <div class="col-sm-5">
-                        <input type="text" class="form-control round-form" id="GSX_KEY" name="GSX_KEY" required>
-                    </div>
-                  </div>
-                  <div class="form-group">
-                    <label class="col-sm-2 col-sm-2 control-label">PiPass DB Worksheet</label>
-                    <div class="col-sm-1">
-                        <input type="text" class="form-control round-form" id="GSX_WORKSHEET" name="GSX_WORKSHEET" required>
-                    </div>
-                  </div>
-                  <div class="form-group">
-                    <label class="col-sm-2 col-sm-2 control-label">Hostapd Driver</label>
-                    <div class="col-sm-2">
-                        <input type="text" class="form-control round-form" id="HOSTAPD_DRIVER" name="HOSTAPD_DRIVER" required>
-                    </div>
-                  </div>
-                  <div class="form-group">
-                    <p class="centered"><button type="submit" class="btn btn-lg btn-theme">Save</button></p>
-                  </div>
-                </form>
-                <script>
-                  $('form').loadJSON('assets/json/pipass_config.json');
-                </script>
+              <div class="showback">
+                <p>
+                  This causes PiPass to immediately advance to the next zone, even if enough time hasn't elapsed.
+                </p>
+                <div class="wrapper">
+                  <p class="centered"><button type="button" class="btn btn-lg btn-theme" onclick="advance()">Advance PiPass</button></p>
+                </div>
               </div>
             </div>
           </div>
@@ -157,7 +129,7 @@
       <footer class="site-footer">
           <div class="text-center">
               <b>"It's a me, Mario!"</b>
-              <a href="settings.html#" class="go-top">
+              <a href="advance_pi_pass.html#" class="go-top">
                   <i class="fa fa-angle-up"></i>
               </a>
           </div>

--- a/var/www/assets/php/advance.php
+++ b/var/www/assets/php/advance.php
@@ -1,0 +1,3 @@
+<?php
+exec('sudo python /opt/PiPass/piPassCommand.py advance');
+?>

--- a/var/www/refresh_pi_pass.html
+++ b/var/www/refresh_pi_pass.html
@@ -73,6 +73,7 @@
                           <li><a  href="start_pi_pass.html">Start</a></li>
                           <li><a  href="stop_pi_pass.html">Stop</a></li>
                           <li class="active"><a  href="refresh_pi_pass.html">Refresh</a></li>
+                          <li><a  href="advance_pi_pass.html">Advance</a></li>
                           <li><a  href="settings.html">Settings</a></li>
                       </ul>
                   </li>

--- a/var/www/start_pi_pass.html
+++ b/var/www/start_pi_pass.html
@@ -73,6 +73,7 @@
                           <li class="active"><a  href="start_pi_pass.html">Start</a></li>
                           <li><a  href="stop_pi_pass.html">Stop</a></li>
                           <li><a  href="refresh_pi_pass.html">Refresh</a></li>
+                          <li><a  href="advance_pi_pass.html">Advance</a></li>
                           <li><a  href="settings.html">Settings</a></li>
                       </ul>
                   </li>

--- a/var/www/stop_pi_pass.html
+++ b/var/www/stop_pi_pass.html
@@ -73,6 +73,7 @@
                           <li><a  href="start_pi_pass.html">Start</a></li>
                           <li class="active"><a  href="stop_pi_pass.html">Stop</a></li>
                           <li><a  href="refresh_pi_pass.html">Refresh</a></li>
+                          <li><a  href="advance_pi_pass.html">Advance</a></li>
                           <li><a  href="settings.html">Settings</a></li>
                       </ul>
                   </li>


### PR DESCRIPTION
These changes update piPass to use signals rather than the flag file. They also add a new "advance" command for advancing to the next zone.

I don't think the flag file was an issue, but since I was adding the signal support for advancing I thought it made sense to apply it to settings refreshing as well. I doubt the reduced I/O will make a meaningful difference on the lifespan of an SD card, but it does have the perk of immediately picking up changes to the Cycle Time.

The "advance" feature allows me to keep my Cycle time at a reasonably high level while still allowing me to manually advance as needed when I'm actively trying to play Mii Plaza or other games and get lots of Street Passes through.
